### PR TITLE
fix(node): add missing package.json "main" field

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.2.0",
   "type": "module",
   "module": "dist/index.min.js",
+  "main": "dist/index.min.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist/**/*.js",


### PR DESCRIPTION
Without this, `import {} from 'jtd-ts'` fails in Node.